### PR TITLE
Update vmu_rt1170 for dts for new usb driver.

### DIFF
--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -529,4 +529,12 @@
 
 zephyr_udc0: &usb1 {
 	status = "okay";
+	phy-handle = <&usbphy1>;
+};
+
+&usbphy1 {
+	status = "okay";
+	tx-d-cal = <7>;
+	tx-cal-45-dp-ohms = <6>;
+	tx-cal-45-dm-ohms = <6>;
 };


### PR DESCRIPTION
This updates the vmu1170 for the new zephyr usb stack based on the settings from the base 1170 dts. It is necessary to remove deprecation warnings for esc_passthrough app.