### PR TITLE
Fix typo in i2c_mcux_lpi2c.

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -108,7 +108,7 @@ static int mcux_lpi2c_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	ret = k_sem_take(&data->lock, SEM_LOCK_TIMEOUT);
+	ret = k_sem_take(&data->lock, k_SEM_LOCK_TIMEOUT);
 	if (ret) {
 		ret = -ETIMEDOUT;
 		return ret;


### PR DESCRIPTION
I ran into this when building esc_passthrough app with flexio support on vmu_rt1170. It is required for that branch to build.