### PR TITLE
drivers: sensor: icm45686: check iodev_sqe before dereferencing it

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -185,7 +185,7 @@ static void icm45686_event_handler(const struct device *dev)
 {
 	struct icm45686_data *data = dev->data;
 	const struct icm45686_config *cfg = dev->config;
-	const struct sensor_read_config *read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
+	const struct sensor_read_config *read_cfg;
 	uint8_t val = 0;
 	uint64_t cycles;
 	int err;
@@ -209,6 +209,13 @@ static void icm45686_event_handler(const struct device *dev)
 		data->stream.settings.enabled.fifo_full = false;
 		return;
 	}
+
+	/* Only valid once the submission above is known to be present: a
+	 * data-ready interrupt can arrive after the stream was torn down, and
+	 * dereferencing a NULL iodev_sqe here faults instead of taking the
+	 * disable path this check exists for.
+	 */
+	read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
 
 	if (atomic_cas(&data->stream.state, ICM45686_STREAM_ON, ICM45686_STREAM_BUSY) == false) {
 		LOG_WRN("Event handler triggered while a stream is in progress! Ignoring");


### PR DESCRIPTION
icm45686_event_handler() read data->stream.iodev_sqe->sqe.iodev->data into read_cfg on entry, four lines above the guard that exists precisely because that pointer can be NULL. A data-ready interrupt arriving after the stream was torn down therefore dereferenced NULL instead of taking the branch that disables the interrupt.

On an MIMXRT1064 this is not a benign NULL read: ITCM is mapped at address 0, so the load returns whatever code happens to live there and the handler then dereferences that value as a pointer. The result was an unaligned word access, K_ERR_ARM_USAGE_UNALIGNED_ACCESS, and a fatal halt with interrupts locked -- every thread left queued and nothing scheduled again.

read_cfg is not used until well after the guard, so assigning it there costs nothing and lets the existing check do its job.